### PR TITLE
Update Dockerfile - update to latest version of bw cli: v2023.10.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm
 
 # note to self: we need to have renovate bot update this somehow
-ENV BW_CLI_VERSION=2023.7.0
+ENV BW_CLI_VERSION=2023.10.0
 
 RUN apt update && \
     apt list --upgradeable | grep security | cut -f1 -d '/' | xargs apt-get install --no-install-recommends -y && \


### PR DESCRIPTION
This is the latest version in the releases here:
https://github.com/bitwarden/clients/releases/tag/cli-v2023.10.0

For longer term maintenance, see also: https://github.com/small-hack/bitwarden-eso-provider/issues/71