### PR TITLE
feat: Terminate dns name of default loginUrl

### DIFF
--- a/charts/bitwarden-eso-provider/Chart.yaml
+++ b/charts/bitwarden-eso-provider/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # renovate: image=jessebot/bweso
 appVersion: "v0.3.0"

--- a/charts/bitwarden-eso-provider/templates/_helpers.tpl
+++ b/charts/bitwarden-eso-provider/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Create the url string that will be used to query Bitwarden:
 - cluster-secret-store logins url
 */}}
 {{- define "bitwarden-eso-provider.clusterSecretStore.loginUrl" -}}
-{{- printf "http://%s.%s.svc.cluster.local:%s/list/object/items?search={{ .remoteRef.key }}" .Release.Name .Release.Namespace (.Values.service.port | toString) | quote }}
+{{- printf "http://%s.%s.svc.cluster.local.:%s/list/object/items?search={{ .remoteRef.key }}" .Release.Name .Release.Namespace (.Values.service.port | toString) | quote }}
 {{- end }}
 
 


### PR DESCRIPTION
This changeset sets the bitwarden-eso-provider.clusterSecretStore.loginUrl to be terminated with a `.` so that the search domain is not appended to the hostname ideally forcing it to resolve within the cluster.