### PR TITLE
feat: support BW_APPID

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
 set -e
+
+if [ -n "$BW_APPID" ]; then
+	mkdir -p ~/.config/Bitwarden\ CLI/
+	echo "{\"appId\":\"$BW_APPID\"}" >~/.config/Bitwarden\ CLI/data.json
+fi
+
 echo "starting entrypoint script"
 
 echo "configuring the server host: $BW_HOST"


### PR DESCRIPTION
This changeset adds support for the BW_APPID environment variable so that the pod can be uniquely identified making it easier to identify when a new login is detected.

Refs: #81