### PR TITLE
feat: upgrade to external-secrets.io/v1 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ By default we will create three `ClusterSecretStores` for you (logins, fields & 
 
 ```yaml
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   # name of the ExternalSecret itself

--- a/charts/bitwarden-eso-provider/templates/cluster-secret-stores.yaml
+++ b/charts/bitwarden-eso-provider/templates/cluster-secret-stores.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.bitwarden_eso_provider.create_cluster_secret_store }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: bitwarden-login
@@ -13,7 +13,7 @@ spec:
       result:
         jsonPath: {{ include "bitwarden-eso-provider.clusterSecretStore.loginJsonPath" . }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: bitwarden-fields
@@ -24,7 +24,7 @@ spec:
       result:
         jsonPath: {{ include "bitwarden-eso-provider.clusterSecretStore.fieldsJsonPath" . }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: bitwarden-notes

--- a/examples/example-secret.yaml
+++ b/examples/example-secret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   # this is the name of the ExternalSecret object


### PR DESCRIPTION
## Description
This PR upgrades the Bitwarden ESO Provider to use the new `external-secrets.io/v1` API instead of the deprecated `v1beta1` version. This change is necessary to maintain compatibility with the latest version of External Secrets Operator.

## Changes
- Updated all CRD definitions from `external-secrets.io/v1beta1` to `external-secrets.io/v1`
- Updated all YAML templates to use the new API version
- Updated chart version to reflect the API change


## Breaking Changes
This is a breaking change that requires users to upgrade their External Secrets Operator to a version that supports the v1 API.

## Related Issues
https://github.com/external-secrets/external-secrets/releases/tag/v0.17.0
