### PR TITLE
update the apiVersion everywhere to v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ By default we will create three `ClusterSecretStores` for you (logins, fields & 
 
 ```yaml
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   # name of the ExternalSecret itself

--- a/charts/bitwarden-eso-provider/Chart.yaml
+++ b/charts/bitwarden-eso-provider/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.15.0
+version: 1.0.0
 
 # renovate: image=jessebot/bweso
 appVersion: 0.16.0
@@ -24,6 +24,7 @@ maintainers:
   - name: "cloudymax"
     email: "emax@cloudydev.net"
     url: "https://github.com/cloudymax/"
+
   - name: "jessebot"
     email: "jessebot@linux.com"
     url: "https://github.com/jessebot/"

--- a/charts/bitwarden-eso-provider/README.md
+++ b/charts/bitwarden-eso-provider/README.md
@@ -1,6 +1,6 @@
 # bitwarden-eso-provider
 
-![Version: 0.15.0](https://img.shields.io/badge/Version-0.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.0](https://img.shields.io/badge/AppVersion-0.16.0-informational?style=flat-square)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.16.0](https://img.shields.io/badge/AppVersion-0.16.0-informational?style=flat-square)
 
 Helm chart to use Bitwarden as a Provider for External Secrets Operator
 

--- a/charts/bitwarden-eso-provider/templates/cluster-secret-stores.yaml
+++ b/charts/bitwarden-eso-provider/templates/cluster-secret-stores.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.bitwarden_eso_provider.create_cluster_secret_store }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: bitwarden-login
@@ -13,7 +13,7 @@ spec:
       result:
         jsonPath: {{ include "bitwarden-eso-provider.clusterSecretStore.loginJsonPath" . }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: bitwarden-fields
@@ -24,7 +24,7 @@ spec:
       result:
         jsonPath: {{ include "bitwarden-eso-provider.clusterSecretStore.fieldsJsonPath" . }}
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
   name: bitwarden-notes

--- a/examples/example-secret.yaml
+++ b/examples/example-secret.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: external-secrets.io/v1beta1
+apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
   # this is the name of the ExternalSecret object


### PR DESCRIPTION
## Description
This PR upgrades the Bitwarden ESO Provider to use the new `external-secrets.io/v1` API instead of the deprecated `v1beta1` version. This change is necessary to maintain compatibility with the latest version of External Secrets Operator.

## Changes
- Updated all CRD definitions from `external-secrets.io/v1beta1` to `external-secrets.io/v1`
- Updated all YAML templates to use the new API version
- Updated chart version to reflect the API change


## Breaking Changes
This is a breaking change that requires users to upgrade their External Secrets Operator to a version that supports the v1 API.

## Related Issues
https://github.com/external-secrets/external-secrets/releases/tag/v0.17.0

## Attribution
Kind regards to @Tomyail in #159 as well for getting to this yesterday 💙 